### PR TITLE
Update github actions for submodules

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,12 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: SymbulationEmp
-
-      - name: Checkout Empirical
-        uses: actions/checkout@v2
-        with:
-          repository: devosoft/Empirical
-          path: Empirical
           submodules: "recursive"
 
       - name: run symbulation


### PR DESCRIPTION
This should fix the build failure in https://github.com/anyaevostinar/SymbulationEmp/pull/126. These changes 1) tell Github Actions to clone Symbuilation recursively, so that all of the submodules get cloned too, and 2) stop telling Github Actions to separately clone Empirical.

If you merge this pull request, the update should automatically get merged into the pull request on the main repo.